### PR TITLE
Edit: exec_script.c now correctly counts lines. monty_init.c, correct…

### DIFF
--- a/exec_script.c
+++ b/exec_script.c
@@ -7,12 +7,12 @@
 void exec_script(stack_t **stack)
 {
 	const char delim = ' ';
-	size_t line = 1, nchars = 0;
+	size_t line = 0, nchars = 0;
 	stack_t *temp;
 	void (*f)(stack_t **stack, unsigned int line_number);
 
 	/*Read each line of your Monty script*/
-	while (getline(&data.buf, &nchars, data.script) != EOF && line++)
+	while (getline(&data.buf, &nchars, data.script) != EOF && ++line)
 	{
 		squeeze_spaces(data.buf); /*Sanitize the input*/
 		if (*(data.buf))

--- a/monty_init.c
+++ b/monty_init.c
@@ -5,10 +5,10 @@ FILE *monty_init(int ac, char *av[])
 
 /*Check for correct usage.*/
 	if (ac != 2)
-		fprintf(stderr, "Usage: %s file\n", av[0]), exit(EXIT_FAILURE);
+		fprintf(stderr, "USAGE: %s file\n", av[0]), exit(EXIT_FAILURE);
 	/*Check whether the file exists and is readable.*/
 	if (access(av[1], F_OK | R_OK))
-		fprintf(stderr, "Error: Can't open file: %s\n", av[1]), exit(EXIT_FAILURE);
+		fprintf(stderr, "Error: Can't open file %s\n", av[1]), exit(EXIT_FAILURE);
 	/*If you argued correctly, the file is opened*/
 	data.script = temp = fopen(av[1], "r");
 

--- a/ops.c
+++ b/ops.c
@@ -15,6 +15,8 @@ void push(stack_t **stack, unsigned int line_number)
 		goto fail;
 	for (i = 0; arg[i] && arg[i] != 32; i++)
 	{
+		if (arg[i] == '-')
+			continue;
 		if (arg[i] == 32 || arg[i] < 48 || arg[i] > 57)
 		{
 fail:			fprintf(stderr, "L%u: usage: push integer\n", line_number);
@@ -29,24 +31,20 @@ fail:			fprintf(stderr, "L%u: usage: push integer\n", line_number);
 			exit(EXIT_FAILURE);
 		}
 	}
-
 	newNode = malloc(sizeof(*newNode));
 	if (!newNode)
-		return;
+		fprintf(stderr, "Error: malloc failed\n"), exit(EXIT_FAILURE);
 	newNode->n = atoi(arg);
-	newNode->next = NULL;
-	newNode->prev = NULL;
-
-	if (!*stack)
+	newNode->next = newNode->prev = NULL;
+	if (*stack)
 	{
-		*stack = newNode;
-		return;
-	}
-	temp = *stack;
-	while (temp->next)
+	for (temp = *stack; temp->next;)
 		temp = temp->next;
 	temp->next = newNode;
 	newNode->prev = temp;
+	return;
+	}
+	*stack = newNode;
 }
 /**
  * pall - prints all elements of @stack
@@ -70,8 +68,13 @@ void pall(stack_t **stack, NOT USED unsigned int line_num)
 		}
 	}
 }
-
+/**
+ * nop - NO operator, does nothing.
+ * @stack: ignored
+ * @line_number: ignored
+ */
 void nop(NOT USED stack_t **stack, NOT USED unsigned int line_number)
 {
-	return;
+	(void) stack;
+	(void) line_number;
 }


### PR DESCRIPTION
…ed spelling

of error messages. Ops.c, can now store negative integers and handles bac
mallocs by printing an error and exiting instead of just returning.